### PR TITLE
registry: Remove old format TXT record creation

### DIFF
--- a/registry/txt.go
+++ b/registry/txt.go
@@ -220,16 +220,17 @@ func (im *TXTRegistry) generateTXTRecord(r *endpoint.Endpoint) []*endpoint.Endpo
 
 	endpoints := make([]*endpoint.Endpoint, 0)
 
-	if !im.txtEncryptEnabled && !im.mapper.recordTypeInAffix() && r.RecordType != endpoint.RecordTypeAAAA {
-		// old TXT record format
-		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey))
-		if txt != nil {
-			txt.WithSetIdentifier(r.SetIdentifier)
-			txt.Labels[endpoint.OwnedRecordLabelKey] = r.DNSName
-			txt.ProviderSpecific = r.ProviderSpecific
-			endpoints = append(endpoints, txt)
-		}
-	}
+	//mnairn: Seems to be no way to prevent the creation of the old format TXT records other than removing the code
+	//if !im.txtEncryptEnabled && !im.mapper.recordTypeInAffix() && r.RecordType != endpoint.RecordTypeAAAA {
+	//	// old TXT record format
+	//	txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), endpoint.RecordTypeTXT, r.Labels.Serialize(true, im.txtEncryptEnabled, im.txtEncryptAESKey))
+	//	if txt != nil {
+	//		txt.WithSetIdentifier(r.SetIdentifier)
+	//		txt.Labels[endpoint.OwnedRecordLabelKey] = r.DNSName
+	//		txt.ProviderSpecific = r.ProviderSpecific
+	//		endpoints = append(endpoints, txt)
+	//	}
+	//}
 	// new TXT record format (containing record type)
 	recordType := r.RecordType
 	// AWS Alias records are encoded as type "cname"


### PR DESCRIPTION
Currently the default TXT registry behaviour is to create old and new format records for every record(endpoint) being managed meaning you end up with three records in the provider per endpoint. This seems not required, and just leads to more records being created than are needed.
